### PR TITLE
No global state

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,6 @@ function MemDB (opts, fn) {
   if (typeof opts == 'string') opts = {};
   opts = opts || {};
   opts.db = function (l) { return new memdown(l) };
-  return levelup('mem', opts, fn);
+  return levelup('', opts, fn);
 }
 

--- a/test/memdb.js
+++ b/test/memdb.js
@@ -12,3 +12,18 @@ test('MemDB', function (t) {
     });
   });
 });
+
+test('no global state', function (t) {
+  t.plan(3);
+
+  var a = MemDB();
+  var b = MemDB();
+
+  a.put('foo', 'bar', function (err) {
+    t.error(err);
+    b.get('foo', function (err, val) {
+      t.ok(err, 'had error')
+      t.notEqual(val, 'bar')
+    });
+  });
+});


### PR DESCRIPTION
It seems that if you create two instances of memdown with the same location they'll share state :(.

This means that currently if you create two instances of memdown they'll share data since memdb uses `mem` as the location always. You can opt out of this behaiviour in memdown by setting an empty location which this PR does.

I've added a test case for this as well